### PR TITLE
Update FNModulePrecooler.cs for more functionality

### DIFF
--- a/FNPlugin/FNModulePreecooler.cs
+++ b/FNPlugin/FNModulePreecooler.cs
@@ -20,9 +20,64 @@ namespace FNPlugin {
                     List<ModuleResourceIntake> mres = attach_node.attachedPart.FindModulesImplementing<ModuleResourceIntake>().Where(mre => mre.resourceName == "IntakeAir").ToList();
                     if(mres.Count > 0) {
                         attachedIntake = mres.First();
+                        break;                          //added by attosecond 3/10/14 -- no need to keep the loop going if we found what we wanted
                     }
                 }
             }
+            
+            /*Added by attosecond 3/10/14. Code checks if this is an "all-in-one" intake + precooler part, also checks
+             * parts attached to children and parent parts for intakes, on the assumption that the child/parent parts can
+             * transfer the intake air to the precooler */
+
+            //first check if this is an all-in-one part
+            if (attachedIntake == null)
+            {
+                List<ModuleResourceIntake> mres = part.FindModulesImplementing<ModuleResourceIntake>().Where(mre => mre.resourceName == "IntakeAir").ToList();
+                if (mres.Count > 0)
+                    attachedIntake = mres.First();
+            }
+
+            //now check all parts attached to the parent part
+            if (attachedIntake == null)
+            {
+                foreach (AttachNode attach_node in part.parent.attachNodes)
+                {
+                    if (attach_node.attachedPart != null && attach_node.attachedPart != part)
+                    {
+                        List<ModuleResourceIntake> mres = attach_node.attachedPart.FindModulesImplementing<ModuleResourceIntake>().Where(mre => mre.resourceName == "IntakeAir").ToList();
+                        if (mres.Count > 0)
+                        {
+                            attachedIntake = mres.First();
+                            break;
+                        }
+                    }
+                }
+            }
+
+            //and do the same for child parts
+            if (attachedIntake == null)
+            {
+                foreach (Part childpart in part.children)
+                {
+                    foreach (AttachNode attach_node in childpart.attachNodes)
+                    {
+                        if (attach_node.attachedPart != null && attach_node.attachedPart != part)
+                        {
+                            List<ModuleResourceIntake> mres = attach_node.attachedPart.FindModulesImplementing<ModuleResourceIntake>().Where(mre => mre.resourceName == "IntakeAir").ToList();
+                            if (mres.Count > 0)
+                            {
+                                attachedIntake = mres.First();
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
+            /* 
+             * End edits by attosecond
+            */
+            
             part.force_activate();
         }
 


### PR DESCRIPTION
Added two forms of update: allow for a single intake/precooler part (via welding or maybe a new original model) by checking if the precooler part itself provides IntakeAir, and allow for 1 degree of separation by checking not only directly attached parts for IntakeAir, but also checking all parts directly attached to the precooler parent part and the precooler's immediate child parts.
